### PR TITLE
Fix array response

### DIFF
--- a/lib/ffccmmx/client.rb
+++ b/lib/ffccmmx/client.rb
@@ -149,7 +149,7 @@ module Ffccmmx
     end
 
     def send_concurrent_post_request(requests)
-      httpx.bearer_auth(access_token).request(requests).map { |response| Ffccmmx::Response.new(response) }
+      Array(httpx.bearer_auth(access_token).request(requests)).map { |response| Ffccmmx::Response.new(response) }
     end
 
     def access_token_refresh

--- a/spec/ffccmmx_spec.rb
+++ b/spec/ffccmmx_spec.rb
@@ -263,6 +263,34 @@ RSpec.describe Ffccmmx do
         expect(error.cause).to be_a(HTTPX::HTTPError)
       end
     end
+
+    it "send single message" do
+      mock_fcm_send_request(
+        response_status: 200,
+        response_body: { name: "projects/project_id/messages/message_id" }
+      )
+
+      client = Ffccmmx.new("project_id")
+      requests = [
+        {
+          message: {
+            token: "test_device_token_1",
+            notification: {
+              title: "test title 1",
+              body: "test body 1"
+            }
+          }
+        }
+      ]
+      response = client.concurrent_push(requests)
+
+      expect(response.size).to eq(1)
+      response.each do |res|
+        expect(res.value.status).to eq(200)
+        expect(res.value.json["name"]).to start_with("projects/project_id/messages/")
+        expect(res.value.version).to eq("2.0")
+      end
+    end
   end
 
   describe "#subscription" do


### PR DESCRIPTION
httpx `#request` can return to single response. 
<https://gitlab.com/os85/httpx/-/blob/master/lib/httpx/session.rb?ref_type=heads#L107>

`ffccmmx#concurrent_xxx` is using array.